### PR TITLE
Fix word selection logic

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import App from './App'
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+test('renders page heading', () => {
+  render(<App />)
+  const heading = screen.getByText(/hangman game/i)
+  expect(heading).toBeInTheDocument()
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,28 +7,28 @@ import {Word} from "./components/Word";
 import {useState} from "react"
 
 function App() {
-    const[wordGuess, setWordGuess]=useState(()=>{
-        Math.floor(Math.random()*words.length)// random index from 0 to 8 includes
+    const [wordGuess, setWordGuess] = useState(() => {
+        const randomIndex = Math.floor(Math.random() * words.length)
+        return words[randomIndex]
     })
-    const[guessLetters, setGuessLetters]=useState<string[]>([])
+    const [guessLetters, setGuessLetters] = useState<string[]>([])
   return (
-    <div style={{
-        maxWidth: "800px",
-        display: "flex",
-        flexDirection: "column",
-        gap: "2rem",
-        margin: "0 auto",
-        alignItems: "center",
-    }}>
-        <div style={{
-            fontSize: "2rem", textAlign: "center"
-        }}>
-        </div>
-     <Hangman/>
-      <Word/>
+    <div
+        style={{
+            maxWidth: "800px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "2rem",
+            margin: "0 auto",
+            alignItems: "center",
+        }}
+    >
+        <div style={{ fontSize: "2rem", textAlign: "center" }}>Hangman Game</div>
+        <Hangman />
+        <Word wordToGuess={wordGuess} guessLetters={guessLetters} />
         <div style={{ alignSelf: "stretch" }}>
-
-            <Keyboard/></div>
+            <Keyboard />
+        </div>
 
     </div>
   );

--- a/src/components/Word.tsx
+++ b/src/components/Word.tsx
@@ -1,6 +1,9 @@
-export function Word() {
-    const word = "hangman"
-    const guessLetters = ['h', 'a']
+export interface WordProps {
+    wordToGuess: string
+    guessLetters: string[]
+}
+
+export function Word({ wordToGuess, guessLetters }: WordProps) {
     return (
         <div
             style={{
@@ -12,11 +15,14 @@ export function Word() {
                 fontFamily: "monospace",
             }}>
 
-            {word.split("").map((letter, index) => (
-                <span style={{borderBottom: ".1em solid black"}} key={index}>
+            {wordToGuess.split("").map((letter, index) => (
+                <span style={{ borderBottom: ".1em solid black" }} key={index}>
 
-                   <span style={{visibility: guessLetters.includes(letter) ? "visible" : "hidden"}}
-                   >{letter}</span>
+                    <span
+                        style={{ visibility: guessLetters.includes(letter) ? "visible" : "hidden" }}
+                    >
+                        {letter}
+                    </span>
 
                 </span>
             ))}


### PR DESCRIPTION
## Summary
- randomize chosen word correctly
- display the chosen word based on guesses
- update heading and tests

## Testing
- `CI=true npm test --silent -- --watchAll=false`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684a2df44b38832686f3ff0cc14d4c35